### PR TITLE
Copilot/create folders for architectures

### DIFF
--- a/Q+ATLANTIDE/000-099_ATLAS/README.md
+++ b/Q+ATLANTIDE/000-099_ATLAS/README.md
@@ -1,28 +1,108 @@
-# 000-099 ATLAS — Aircraft Top-Level Architecture System
+---
+document_id: QATL-ATLAS1000-ATLAS-README
+title: "000–099 ATLAS — Aircraft Top-Level Architecture System"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: ATLAS
+architecture_name: "Aircraft Top-Level Architecture System"
+master_range: "000–099"
+subrange_count: 9
+governance_class: baseline
+structural_interface_rule: N-005
+primary_q_divisions: [Q-AIR, Q-DATAGOV, Q-GREENTECH, Q-GROUND, Q-HORIZON, Q-MECHANICS, Q-STRUCTURES]
+orb_function_support: [ORB-FIN, ORB-LEG, ORB-MKTG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** ATLAS
-**Master Range:** `000-099`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** Standard
+# 000–099 ATLAS — Aircraft Top-Level Architecture System
 
-## Purpose
+## 1. Purpose
 
-Aircraft top-level architecture band covering identification, ground handling, core aircraft systems, mechanical protection, avionics & APU, primary structures, traditional & alternative propulsion, and aircraft-type expansion.
+Aircraft top-level architecture band covering identification, ground handling, core aircraft systems, mechanical protection, avionics & APU, primary structures, traditional and alternative propulsion, and aircraft-type expansion.
 
-## Sub-ranges (`XX0-XX9`)
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
 
-| Subrange | Block | Primary Q-Division |
-|---:|---|---|
-| 000-009 | Información General y Servicio | Q-DATAGOV |
-| 010-019 | Manejo en Tierra & Servicio | Q-GROUND |
-| 020-029 | Sistemas Core de Aeronave | Q-AIR |
-| 030-039 | Protección & Sistemas Mecánicos | Q-MECHANICS |
-| 040-049 | Aviónica, Información & APU | Q-DATAGOV |
-| 050-059 | Estructuras Primarias e Interfaces de Programa / Q-Division | Q-STRUCTURES |
-| 060-079 | Propulsión Tradicional & Eco-Tech | Q-GREENTECH |
-| 080-089 | Propulsión Alternativa & Cuántica | Q-GREENTECH |
-| 090-099 | Tipos Específicos & Expansión | Q-HORIZON |
+## 2. Glossary of Terms & Acronyms
+
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| ATLAS | Aircraft Top-Level Architecture System | Aircraft architecture band `000-099`. |
+| APU | Auxiliary Power Unit | Onboard auxiliary power generator. |
+| BWB | Blended Wing Body | Aircraft configuration family. |
+| CMS | Central Maintenance System | Onboard maintenance computing function. |
+| ECS | Environmental Control System | Cabin air conditioning and pressurisation. |
+| GSE | Ground Support Equipment | Ground operations and maintenance support. |
+| HVDC | High Voltage Direct Current | Electrical distribution and propulsion systems. |
+| IMA | Integrated Modular Avionics | Aircraft avionics architecture. |
+| LH₂ | Liquid Hydrogen | Cryogenic hydrogen fuel / energy carrier. |
+| WTW | Wide Tube and Wing | Aircraft configuration family. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
+
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
+
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 000–009 | Información General y Servicio | Identificación, configuración, documentación general, operaciones básicas | Q-DATAGOV | Q-GROUND, Q-AIR | ORB-PMO, ORB-LEG |
+| 010–019 | Manejo en Tierra & Servicio | Ground handling, servicing, acceso, remolque, parking, GSE | Q-GROUND | Q-MECHANICS, Q-INDUSTRY | ORB-PMO, ORB-FIN |
+| 020–029 | Sistemas Core de Aeronave | Aviónica base, eléctrica, hidráulica, ECS, fuel, flight control | Q-AIR | Q-MECHANICS, Q-DATAGOV, Q-GREENTECH | ORB-PMO, ORB-LEG |
+| 030–039 | Protección & Sistemas Mecánicos | Ice/rain protection, fire protection, tren, actuadores | Q-MECHANICS | Q-AIR, Q-STRUCTURES | ORB-PMO, ORB-LEG |
+| 040–049 | Aviónica, Información & APU | IMA, redes de datos, CMS, APU, onboard information systems | Q-DATAGOV | Q-AIR, Q-SPACE, Q-HPC | ORB-PMO, ORB-LEG |
+| 050–059 | Estructuras Primarias e Interfaces de Programa / Q-Division | Fuselaje, alas, BWB, WTW, zonas estructurales, interfaces técnicas | Q-STRUCTURES | Q-AIR, Q-INDUSTRY, Q-HPC | ORB-PMO, ORB-FIN, ORB-LEG |
+| 060–079 | Propulsión Tradicional & Eco-Tech | Turbofan, híbrido-eléctrico, thermal management, nacelles | Q-GREENTECH | Q-MECHANICS, Q-AIR, Q-INDUSTRY | ORB-PMO, ORB-FIN |
+| 080–089 | Propulsión Alternativa & Cuántica | LH₂, fuel cells, HVDC, superconductores, Q-sensing | Q-GREENTECH | Q-HORIZON, Q-HPC, Q-STRUCTURES | ORB-PMO, ORB-LEG, ORB-FIN |
+| 090–099 | Tipos Específicos & Expansión | Variantes BWB/WTW, demostradores, clases especiales de aeronaves | Q-HORIZON | Q-AIR, Q-STRUCTURES, Q-GREENTECH | ORB-PMO, ORB-MKTG |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `000–099` |
+| Sub-ranges | 9 |
+| Architecture code | `ATLAS` |
+| Governance class | `baseline` |
+| Restricted band | No |
+| Primary Q-Divisions | Q-AIR, Q-DATAGOV, Q-GREENTECH, Q-GROUND, Q-HORIZON, Q-MECHANICS, Q-STRUCTURES |
+| Folder path | `Q+ATLANTIDE/000-099_ATLAS/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
+| Structural-interface rule | Sub-range `050–059` shall use the title fragment *Estructuras Primarias e Interfaces de Programa / Q-Division* (rule N-005[^n005]). |
 
 ## Governance
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates declared in this band must populate `architecture_band`, `architecture_code = ATLAS`, `q_division_owner` and `orb_function_support`. The **No-AAA Rule (N-004)** applies: do not use "AAA" — use "Programme / Q-Division Interface" instead. Subrange `050-059` shall use the title fragment **"Estructuras Primarias e Interfaces de Programa / Q-Division"** (N-005).
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = ATLAS`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
+
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n005]: **Note N-005** — `ATLAS 050–059` shall use *Estructuras Primarias e Interfaces de Programa / Q-Division*. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/000-099_ATLAS/README.md
+++ b/Q+ATLANTIDE/000-099_ATLAS/README.md
@@ -1,0 +1,28 @@
+# 000-099 ATLAS — Aircraft Top-Level Architecture System
+
+**Architecture Code:** ATLAS
+**Master Range:** `000-099`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** Standard
+
+## Purpose
+
+Aircraft top-level architecture band covering identification, ground handling, core aircraft systems, mechanical protection, avionics & APU, primary structures, traditional & alternative propulsion, and aircraft-type expansion.
+
+## Sub-ranges (`XX0-XX9`)
+
+| Subrange | Block | Primary Q-Division |
+|---:|---|---|
+| 000-009 | Información General y Servicio | Q-DATAGOV |
+| 010-019 | Manejo en Tierra & Servicio | Q-GROUND |
+| 020-029 | Sistemas Core de Aeronave | Q-AIR |
+| 030-039 | Protección & Sistemas Mecánicos | Q-MECHANICS |
+| 040-049 | Aviónica, Información & APU | Q-DATAGOV |
+| 050-059 | Estructuras Primarias e Interfaces de Programa / Q-Division | Q-STRUCTURES |
+| 060-079 | Propulsión Tradicional & Eco-Tech | Q-GREENTECH |
+| 080-089 | Propulsión Alternativa & Cuántica | Q-GREENTECH |
+| 090-099 | Tipos Específicos & Expansión | Q-HORIZON |
+
+## Governance
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates declared in this band must populate `architecture_band`, `architecture_code = ATLAS`, `q_division_owner` and `orb_function_support`. The **No-AAA Rule (N-004)** applies: do not use "AAA" — use "Programme / Q-Division Interface" instead. Subrange `050-059` shall use the title fragment **"Estructuras Primarias e Interfaces de Programa / Q-Division"** (N-005).

--- a/Q+ATLANTIDE/100-199_STA/README.md
+++ b/Q+ATLANTIDE/100-199_STA/README.md
@@ -1,26 +1,100 @@
-# 100-199 STA — Space Technology Architecture
+---
+document_id: QATL-ATLAS1000-STA-README
+title: "100–199 STA — Space Technology Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: STA
+architecture_name: "Space Technology Architecture"
+master_range: "100–199"
+subrange_count: 10
+governance_class: baseline
+primary_q_divisions: [Q-GREENTECH, Q-HORIZON, Q-SPACE, Q-STRUCTURES]
+orb_function_support: [ORB-FIN, ORB-LEG, ORB-MKTG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** STA
-**Master Range:** `100-199`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** Standard
+# 100–199 STA — Space Technology Architecture
 
-## Purpose
+## 1. Purpose
 
-Space technology architecture band covering general space systems and life support, space structures and materials, traditional and advanced space propulsion, space energy, mission avionics & control, and related space-segment domains.
+Space technology architecture band covering general space systems and life support, space structures and materials, traditional and advanced propulsion, space energy, mission avionics & control, communications, payloads, on-orbit operations, infrastructure & logistics, and future space concepts.
 
-## Representative Sub-ranges (`XX0-XX9`)
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
 
-| Subrange | Block | Primary Q-Division |
-|---:|---|---|
-| 100-109 | Sistemas Generales y Soporte Vital Espacial | Q-SPACE |
-| 110-119 | Estructuras y Materiales Espaciales | Q-STRUCTURES |
-| 120-129 | Propulsión Espacial Tradicional y Avanzada | Q-GREENTECH |
-| 130-139 | Sistemas de Energía Espacial | Q-GREENTECH |
-| 140-149 | Aviónica y Control de Misión Espacial | Q-SPACE |
+## 2. Glossary of Terms & Acronyms
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for the full subrange table.
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| STA | Space Technology Architecture | Space architecture band `100-199`. |
+| GNC | Guidance, Navigation and Control | Space and aerospace control systems. |
+| Satcom | Satellite Communications | Space-segment communications systems. |
+| Cis-lunar | Cis-lunar Space | Region of space between Earth and the Moon. |
+| MRO | Maintenance, Repair and Overhaul | Lifecycle support discipline. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
+
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
+
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 100–109 | Sistemas Generales y Soporte Vital Espacial | Arquitectura general espacial, habitabilidad, soporte vital, seguridad de misión | Q-SPACE | Q-DATAGOV, Q-HORIZON | ORB-PMO, ORB-LEG |
+| 110–119 | Estructuras y Materiales Espaciales | Estructuras orbitales, materiales espaciales, protección térmica y radiación | Q-STRUCTURES | Q-SPACE, Q-HORIZON, Q-INDUSTRY | ORB-PMO, ORB-FIN |
+| 120–129 | Propulsión Espacial Tradicional y Avanzada | Propulsión química, eléctrica, nuclear conceptual, avanzada | Q-GREENTECH | Q-SPACE, Q-HORIZON, Q-HPC | ORB-PMO, ORB-LEG |
+| 130–139 | Sistemas de Energía Espacial | Solar, baterías, energía nuclear espacial conceptual, distribución eléctrica | Q-GREENTECH | Q-SPACE, Q-HPC | ORB-PMO, ORB-FIN |
+| 140–149 | Aviónica y Control de Misión Espacial | GNC, avionics, flight software, mission control, autonomy | Q-SPACE | Q-DATAGOV, Q-HPC, Q-HORIZON | ORB-PMO, ORB-LEG |
+| 150–159 | Comunicaciones Espaciales | Satcom, enlaces ópticos, redes espaciales, comunicación intersatélite | Q-SPACE | Q-DATAGOV, Q-HPC | ORB-PMO, ORB-LEG |
+| 160–169 | Sensores y Carga Útil Espacial | Payloads, instrumentación, sensores científicos, observación | Q-SPACE | Q-HORIZON, Q-HPC, Q-DATAGOV | ORB-PMO, ORB-MKTG |
+| 170–179 | Operaciones y Mantenimiento en Órbita | Servicing orbital, inspección, reparación, ensamblaje en órbita | Q-SPACE | Q-GROUND, Q-HORIZON, Q-MECHANICS | ORB-PMO, ORB-LEG |
+| 180–189 | Infraestructura y Logística Espacial | Bases orbitales, logística cis-lunar, transporte espacial, recursos | Q-SPACE | Q-INDUSTRY, Q-GROUND, Q-HORIZON | ORB-PMO, ORB-FIN |
+| 190–199 | Sistemas Avanzados, Conceptos y Futuro Espacial | Interplanetario, hábitats avanzados, conceptos post-2040 | Q-HORIZON | Q-SPACE, Q-HPC, Q-GREENTECH | ORB-PMO, ORB-MKTG |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `100–199` |
+| Sub-ranges | 10 |
+| Architecture code | `STA` |
+| Governance class | `baseline` |
+| Restricted band | No |
+| Primary Q-Divisions | Q-GREENTECH, Q-HORIZON, Q-SPACE, Q-STRUCTURES |
+| Folder path | `Q+ATLANTIDE/100-199_STA/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
 
 ## Governance
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = STA`, `q_division_owner` and `orb_function_support`.
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = STA`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
+
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/100-199_STA/README.md
+++ b/Q+ATLANTIDE/100-199_STA/README.md
@@ -1,0 +1,26 @@
+# 100-199 STA — Space Technology Architecture
+
+**Architecture Code:** STA
+**Master Range:** `100-199`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** Standard
+
+## Purpose
+
+Space technology architecture band covering general space systems and life support, space structures and materials, traditional and advanced space propulsion, space energy, mission avionics & control, and related space-segment domains.
+
+## Representative Sub-ranges (`XX0-XX9`)
+
+| Subrange | Block | Primary Q-Division |
+|---:|---|---|
+| 100-109 | Sistemas Generales y Soporte Vital Espacial | Q-SPACE |
+| 110-119 | Estructuras y Materiales Espaciales | Q-STRUCTURES |
+| 120-129 | Propulsión Espacial Tradicional y Avanzada | Q-GREENTECH |
+| 130-139 | Sistemas de Energía Espacial | Q-GREENTECH |
+| 140-149 | Aviónica y Control de Misión Espacial | Q-SPACE |
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for the full subrange table.
+
+## Governance
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = STA`, `q_division_owner` and `orb_function_support`.

--- a/Q+ATLANTIDE/200-299_DTTA/README.md
+++ b/Q+ATLANTIDE/200-299_DTTA/README.md
@@ -1,21 +1,107 @@
-# 200-299 DTTA — Defence Technology Type Architecture
+---
+document_id: QATL-ATLAS1000-DTTA-README
+title: "200–299 DTTA — Defence Technology Type Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: DTTA
+architecture_name: "Defence Technology Type Architecture"
+master_range: "200–299"
+subrange_count: 10
+governance_class: restricted
+restricted_rule: N-006
+primary_q_divisions: [Q-DATAGOV, Q-GROUND, Q-HORIZON, Q-HPC, Q-STRUCTURES]
+orb_function_support: [ORB-FIN, ORB-HR, ORB-LEG, ORB-MKTG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** DTTA
-**Master Range:** `200-299`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** **Restricted** (per N-006)
+# 200–299 DTTA — Defence Technology Type Architecture
 
-## Purpose
+## 1. Purpose
 
-Defence technology type architecture band covering combat air platforms, defence-type aircraft (including 5th/6th generation and multirole fighters), C4ISR, mission systems, and related defence technologies.
+Defence technology type architecture band covering combat & weapons systems, C4ISR, protection & resilience, defence robotics & autonomous systems, military logistics, cyber-defence & electronic warfare, defence materials & sensors, military simulation & training, quantum warfare, and future operational concepts.
 
-## Governance & Restrictions
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Per **N-006**, templates with `architecture_band` in `200-299` are **restricted** and must additionally declare:
+## 2. Glossary of Terms & Acronyms
 
-- `evidence_package_id`
-- `access_control_profile`
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| DTTA | Defence Technology Type Architecture | Defence architecture band `200-299` (restricted). |
+| C4ISR | Command, Control, Communications, Computers, Intelligence, Surveillance and Reconnaissance | Defence and mission systems classification. |
+| EW | Electronic Warfare | Spectrum operations and electromagnetic effects. |
+| UGV | Unmanned Ground Vehicle | Land-based autonomous platform. |
+| UAV | Unmanned Aerial Vehicle | Air-based autonomous platform. |
+| USV | Unmanned Surface Vehicle | Sea-surface autonomous platform. |
+| XR | Extended Reality | Immersive / mixed / augmented reality technologies. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
 
-Templates must also declare `architecture_code = DTTA`, `q_division_owner` (technical authority) and `orb_function_support` (enterprise support).
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 200–209 | Sistemas de Combate y Armamento | Sistemas de combate, efectos, integración de plataformas | Q-HORIZON | Q-AIR, Q-SPACE, Q-DATAGOV | ORB-LEG, ORB-PMO |
+| 210–219 | C4ISR | Mando, control, comunicaciones, inteligencia, vigilancia, reconocimiento | Q-DATAGOV | Q-SPACE, Q-HPC, Q-AIR | ORB-PMO, ORB-LEG |
+| 220–229 | Protección y Resiliencia | Protección de sistemas, supervivencia, hardening, resiliencia operacional | Q-HORIZON | Q-STRUCTURES, Q-DATAGOV, Q-HPC | ORB-LEG, ORB-PMO |
+| 230–239 | Robótica y Sistemas Autónomos de Defensa | UGV, UAV, USV, autonomía, swarms, control humano-supervisado | Q-HPC | Q-HORIZON, Q-DATAGOV, Q-AIR | ORB-PMO, ORB-LEG |
+| 240–249 | Logística y Mantenimiento en Defensa | MRO militar, logística desplegada, soporte en campaña | Q-GROUND | Q-INDUSTRY, Q-DATAGOV, Q-MECHANICS | ORB-PMO, ORB-FIN |
+| 250–259 | Ciberdefensa y Guerra Electrónica | EW, cyber defence, spectrum operations, resilience | Q-DATAGOV | Q-SPACE, Q-HPC, Q-HORIZON | ORB-LEG, ORB-PMO |
+| 260–269 | Materiales y Sensores para Defensa | Sensores, protección, materiales especiales, stealth conceptual | Q-STRUCTURES | Q-HORIZON, Q-HPC, Q-DATAGOV | ORB-PMO, ORB-LEG |
+| 270–279 | Simulación y Entrenamiento Militar | Synthetic environments, simuladores, wargaming, entrenamiento XR | Q-HPC | Q-DATAGOV, Q-AIR, Q-GROUND | ORB-PMO, ORB-HR |
+| 280–289 | Guerra Cuántica y Tecnologías Disruptivas | Quantum sensing, quantum comms, quantum cyber, tecnologías emergentes | Q-HORIZON | Q-HPC, Q-DATAGOV, Q-SPACE | ORB-LEG, ORB-PMO |
+| 290–299 | Conceptos Operacionales Futuros | Future operating concepts, multi-domain operations, doctrina tecnológica | Q-HORIZON | Q-HPC, Q-DATAGOV, Q-SPACE | ORB-PMO, ORB-MKTG |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `200–299` |
+| Sub-ranges | 10 |
+| Architecture code | `DTTA` |
+| Governance class | `restricted` |
+| Restricted band | Yes (rule N-006[^n006]) |
+| Primary Q-Divisions | Q-DATAGOV, Q-GROUND, Q-HORIZON, Q-HPC, Q-STRUCTURES |
+| Folder path | `Q+ATLANTIDE/200-299_DTTA/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
+
+## Governance
+
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = DTTA`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
+
+**Restricted band (N-006[^n006]).** Templates inside this band must additionally declare `governance_class: restricted`, `evidence_package_id` and `access_control_profile`.
+
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n006]: **Note N-006 (Restricted bands)** — Defence-related (`200-299` DTTA), cybersecurity-related (`800-899` CYB) and quantum-related (`900-999` QCSAA) bands require additional governance, evidence packages and access controls beyond the baseline trace record. Templates must additionally declare `governance_class: restricted`, `evidence_package_id` and `access_control_profile`. See [`organization/Q+ATLANTIDE.md` §5.3](../../organization/Q+ATLANTIDE.md#53-restricted-band-templates-n-006).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/200-299_DTTA/README.md
+++ b/Q+ATLANTIDE/200-299_DTTA/README.md
@@ -1,0 +1,21 @@
+# 200-299 DTTA — Defence Technology Type Architecture
+
+**Architecture Code:** DTTA
+**Master Range:** `200-299`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** **Restricted** (per N-006)
+
+## Purpose
+
+Defence technology type architecture band covering combat air platforms, defence-type aircraft (including 5th/6th generation and multirole fighters), C4ISR, mission systems, and related defence technologies.
+
+## Governance & Restrictions
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Per **N-006**, templates with `architecture_band` in `200-299` are **restricted** and must additionally declare:
+
+- `evidence_package_id`
+- `access_control_profile`
+
+Templates must also declare `architecture_code = DTTA`, `q_division_owner` (technical authority) and `orb_function_support` (enterprise support).
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.

--- a/Q+ATLANTIDE/300-399_DTCEC/README.md
+++ b/Q+ATLANTIDE/300-399_DTCEC/README.md
@@ -1,16 +1,102 @@
-# 300-399 DTCEC — Digital Twin, Cloud, Edge & AI Architecture
+---
+document_id: QATL-ATLAS1000-DTCEC-README
+title: "300–399 DTCEC — Digital Twin, Cloud, Edge & AI Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: DTCEC
+architecture_name: "Digital Twin, Cloud, Edge & AI Architecture"
+master_range: "300–399"
+subrange_count: 10
+governance_class: baseline
+primary_q_divisions: [Q-DATAGOV, Q-HORIZON, Q-HPC]
+orb_function_support: [ORB-FIN, ORB-HR, ORB-LEG, ORB-MKTG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** DTCEC
-**Master Range:** `300-399`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** Standard
+# 300–399 DTCEC — Digital Twin, Cloud, Edge & AI Architecture
 
-## Purpose
+## 1. Purpose
 
-Digital architecture band covering digital twins, cloud and edge computing, artificial intelligence, MBSE, PLM integration, data governance pipelines, and the digital backbone supporting all other ATLAS-1000 architectures.
+Digital architecture band covering digital twin foundations, IoT sensing, AI/ML, cloud & edge computing, advanced simulation & MBSE, extended reality, blockchain, cybersecurity for digital twins, analytics & BI, and adaptive/conscious twins.
+
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
+
+## 2. Glossary of Terms & Acronyms
+
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| DTCEC | Digital Twin, Cloud, Edge & AI Architecture | Digital architecture band `300-399`. |
+| CFD | Computational Fluid Dynamics | Simulation of fluid flow. |
+| DPP | Digital Product Passport | Lifecycle traceability and circularity artefact. |
+| FEA | Finite Element Analysis | Structural simulation method. |
+| IETP | Interactive Electronic Technical Publication | Interactive maintenance / operations publication. |
+| MBSE | Model-Based Systems Engineering | Systems architecture and verification method. |
+| XR | Extended Reality | Immersive / mixed / augmented reality technologies. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
+
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
+
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 300–309 | Fundamentos de Gemelos Digitales | Modelos digitales, sincronización, baseline, configuración | Q-DATAGOV | Q-HPC, Q-INDUSTRY | ORB-PMO, ORB-LEG |
+| 310–319 | Sensores e IoT para Digital Twins | Sensorización, IoT, edge telemetry, data ingestion | Q-DATAGOV | Q-HPC, Q-MECHANICS, Q-SPACE | ORB-PMO, ORB-FIN |
+| 320–329 | IA y Machine Learning para Digital Twins | ML, predictive analytics, anomaly detection, IA certificable | Q-HPC | Q-DATAGOV, Q-AIR, Q-GREENTECH | ORB-PMO, ORB-LEG |
+| 330–339 | Cloud Computing y Arquitecturas Distribuidas | Cloud, edge, federated systems, sovereign infrastructure | Q-DATAGOV | Q-HPC, Q-INDUSTRY | ORB-PMO, ORB-FIN |
+| 340–349 | Simulación y Modelado Avanzado | CFD, FEA, MBSE, mission simulation, multiphysics | Q-HPC | Q-AIR, Q-STRUCTURES, Q-GREENTECH | ORB-PMO |
+| 350–359 | Realidad Extendida y Metaverso | XR, training, immersive IETP, virtual operations | Q-HPC | Q-DATAGOV, Q-GROUND | ORB-HR, ORB-MKTG |
+| 360–369 | Blockchain y Tecnologías Descentralizadas | DPP, traceability ledger, smart contracts, evidence chain | Q-DATAGOV | Q-HPC, Q-INDUSTRY | ORB-LEG, ORB-PMO |
+| 370–379 | Ciberseguridad para Digital Twins | Security-by-design, model integrity, access control, cyber resilience | Q-DATAGOV | Q-HPC, Q-SPACE | ORB-LEG, ORB-PMO |
+| 380–389 | Analytics y Business Intelligence | KPI, EVM analytics, operations intelligence, dashboards | Q-DATAGOV | Q-HPC, Q-INDUSTRY | ORB-PMO, ORB-FIN |
+| 390–399 | Digital Twins Conscientes y Evolutivos | Adaptive twins, self-updating models, governed autonomy | Q-HORIZON | Q-HPC, Q-DATAGOV | ORB-PMO, ORB-LEG |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `300–399` |
+| Sub-ranges | 10 |
+| Architecture code | `DTCEC` |
+| Governance class | `baseline` |
+| Restricted band | No |
+| Primary Q-Divisions | Q-DATAGOV, Q-HORIZON, Q-HPC |
+| Folder path | `Q+ATLANTIDE/300-399_DTCEC/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
 
 ## Governance
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = DTCEC`, `q_division_owner` and `orb_function_support`.
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = DTCEC`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/300-399_DTCEC/README.md
+++ b/Q+ATLANTIDE/300-399_DTCEC/README.md
@@ -1,0 +1,16 @@
+# 300-399 DTCEC — Digital Twin, Cloud, Edge & AI Architecture
+
+**Architecture Code:** DTCEC
+**Master Range:** `300-399`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** Standard
+
+## Purpose
+
+Digital architecture band covering digital twins, cloud and edge computing, artificial intelligence, MBSE, PLM integration, data governance pipelines, and the digital backbone supporting all other ATLAS-1000 architectures.
+
+## Governance
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = DTCEC`, `q_division_owner` and `orb_function_support`.
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.

--- a/Q+ATLANTIDE/400-499_EPTA/README.md
+++ b/Q+ATLANTIDE/400-499_EPTA/README.md
@@ -1,16 +1,100 @@
-# 400-499 EPTA — Energy & Propulsion Technology Architecture
+---
+document_id: QATL-ATLAS1000-EPTA-README
+title: "400–499 EPTA — Energy & Propulsion Technology Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: EPTA
+architecture_name: "Energy & Propulsion Technology Architecture"
+master_range: "400–499"
+subrange_count: 10
+governance_class: baseline
+primary_q_divisions: [Q-GREENTECH, Q-HORIZON, Q-HPC]
+orb_function_support: [ORB-CSR, ORB-FIN, ORB-LEG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** EPTA
-**Master Range:** `400-499`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** Standard
+# 400–499 EPTA — Energy & Propulsion Technology Architecture
 
-## Purpose
+## 1. Purpose
 
-Energy and propulsion technology architecture band covering hydrogen (LH₂) systems, fuel cells, HVDC and superconducting distribution, hybrid-electric propulsion, energy storage, thermal management, and cross-domain energy/propulsion enablers.
+Energy and propulsion technology architecture band covering primary energy sources, renewables, storage, distribution & HVDC, combustion propulsion, electric & hybrid propulsion, hydrogen & fuel cells, novel propulsion concepts, energy/quantum optimisation, and energy recovery.
+
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
+
+## 2. Glossary of Terms & Acronyms
+
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| EPTA | Energy & Propulsion Technology Architecture | Energy and propulsion architecture band `400-499`. |
+| BoP | Balance of Plant | Auxiliary systems supporting a fuel cell or power plant. |
+| HVDC | High Voltage Direct Current | Electrical distribution and propulsion systems. |
+| LH₂ | Liquid Hydrogen | Cryogenic hydrogen fuel / energy carrier. |
+| TRL | Technology Readiness Level | Maturity scale 1–9. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
+
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
+
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 400–409 | Fuentes de Energía Convencionales y Avanzadas | Generación energética, fuentes primarias, arquitecturas de suministro | Q-GREENTECH | Q-HPC, Q-INDUSTRY | ORB-FIN, ORB-PMO |
+| 410–419 | Energías Renovables | Solar, eólica, renovables integradas, infraestructura energética | Q-GREENTECH | Q-INDUSTRY, Q-HORIZON | ORB-CSR, ORB-FIN |
+| 420–429 | Almacenamiento de Energía | Baterías, supercapacitores, almacenamiento criogénico, buffer energético | Q-GREENTECH | Q-STRUCTURES, Q-HPC | ORB-PMO, ORB-LEG |
+| 430–439 | Gestión y Distribución de Energía | HVDC, power management, distribución, protección eléctrica | Q-GREENTECH | Q-MECHANICS, Q-DATAGOV, Q-HPC | ORB-PMO, ORB-LEG |
+| 440–449 | Propulsión por Combustión | Turbinas, combustión, hot section, combustibles sostenibles | Q-GREENTECH | Q-AIR, Q-MECHANICS | ORB-PMO, ORB-FIN |
+| 450–459 | Propulsión Eléctrica e Híbrida | Motores eléctricos, híbrido-eléctrico, conversión, inversores | Q-GREENTECH | Q-HPC, Q-MECHANICS, Q-AIR | ORB-PMO, ORB-LEG |
+| 460–469 | Propulsión de Hidrógeno y Celdas de Combustible | LH₂, fuel cells, BoP, criogenia, seguridad H₂ | Q-GREENTECH | Q-STRUCTURES, Q-MECHANICS, Q-HPC | ORB-PMO, ORB-LEG, ORB-CSR |
+| 470–479 | Nuevas Formas de Propulsión | Propulsión avanzada, conceptos post-2040, experimental TRL bajo | Q-HORIZON | Q-GREENTECH, Q-HPC, Q-SPACE | ORB-PMO, ORB-LEG |
+| 480–489 | Optimización Energética y Cuántica | Optimización energética, quantum optimization, smart energy systems | Q-HPC | Q-GREENTECH, Q-HORIZON | ORB-PMO, ORB-FIN |
+| 490–499 | Sistemas de Recuperación de Energía | Recuperación térmica, regeneración, efficiency recovery systems | Q-GREENTECH | Q-MECHANICS, Q-HPC | ORB-CSR, ORB-FIN |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `400–499` |
+| Sub-ranges | 10 |
+| Architecture code | `EPTA` |
+| Governance class | `baseline` |
+| Restricted band | No |
+| Primary Q-Divisions | Q-GREENTECH, Q-HORIZON, Q-HPC |
+| Folder path | `Q+ATLANTIDE/400-499_EPTA/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
 
 ## Governance
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = EPTA`, `q_division_owner` and `orb_function_support`.
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = EPTA`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/400-499_EPTA/README.md
+++ b/Q+ATLANTIDE/400-499_EPTA/README.md
@@ -1,0 +1,16 @@
+# 400-499 EPTA — Energy & Propulsion Technology Architecture
+
+**Architecture Code:** EPTA
+**Master Range:** `400-499`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** Standard
+
+## Purpose
+
+Energy and propulsion technology architecture band covering hydrogen (LH₂) systems, fuel cells, HVDC and superconducting distribution, hybrid-electric propulsion, energy storage, thermal management, and cross-domain energy/propulsion enablers.
+
+## Governance
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = EPTA`, `q_division_owner` and `orb_function_support`.
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.

--- a/Q+ATLANTIDE/500-599_AMTA/README.md
+++ b/Q+ATLANTIDE/500-599_AMTA/README.md
@@ -1,16 +1,100 @@
-# 500-599 AMTA — Advanced Material, Bio & Nanotechnology Architecture
+---
+document_id: QATL-ATLAS1000-AMTA-README
+title: "500–599 AMTA — Advanced Material, Bio & Nanotechnology Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: AMTA
+architecture_name: "Advanced Material, Bio & Nanotechnology Architecture"
+master_range: "500–599"
+subrange_count: 10
+governance_class: baseline
+primary_q_divisions: [Q-HORIZON, Q-INDUSTRY, Q-STRUCTURES]
+orb_function_support: [ORB-CSR, ORB-FIN, ORB-LEG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** AMTA
-**Master Range:** `500-599`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** Standard
+# 500–599 AMTA — Advanced Material, Bio & Nanotechnology Architecture
 
-## Purpose
+## 1. Purpose
 
-Advanced materials, bio and nanotechnology architecture band covering composites, metamaterials, bio-derived materials, nanotechnology, recycling and circularity (LUTNDR-aligned), and material lifecycle traceability via Digital Product Passport (DPP).
+Advanced materials, bio and nanotechnology architecture band covering advanced composites, metamaterials & smart materials, nanocoatings, biotechnology & bioengineering, biomaterials & bionics, nanorobotics, advanced bio/nano sensors, additive manufacturing, quantum materials, and material recycling & circularity.
+
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
+
+## 2. Glossary of Terms & Acronyms
+
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| AMTA | Advanced Material, Bio & Nanotechnology Architecture | Materials/bio/nano architecture band `500-599`. |
+| CFRP | Carbon Fibre Reinforced Polymer | Advanced structural composite. |
+| DPP | Digital Product Passport | Lifecycle traceability and circularity artefact. |
+| SHM | Structural Health Monitoring | In-service structural integrity monitoring. |
+| LUTNDR | Libro Unico delle Tecnologie (NPR/USO/DIS/RIC) | Technology lifecycle / circularity register cross-referenced for `590-599`. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
+
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
+
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 500–509 | Materiales Compuestos Avanzados | CFRP, composites estructurales, laminados, certificación material | Q-STRUCTURES | Q-INDUSTRY, Q-HPC | ORB-PMO, ORB-FIN |
+| 510–519 | Metamateriales y Materiales Inteligentes | Metamateriales, morphing, smart skins, materiales adaptativos | Q-HORIZON | Q-STRUCTURES, Q-HPC | ORB-PMO, ORB-LEG |
+| 520–529 | Nanomateriales y Recubrimientos Funcionales | Coatings, nano-coatings, anti-icing, protección superficial | Q-STRUCTURES | Q-HORIZON, Q-INDUSTRY | ORB-PMO, ORB-LEG |
+| 530–539 | Biotecnología y Bioingeniería | Bioengineering, biofabrication, materiales bioinspirados | Q-HORIZON | Q-STRUCTURES, Q-GREENTECH | ORB-CSR, ORB-LEG |
+| 540–549 | Biomateriales y Biónica | Biomateriales, estructuras biónicas, sistemas bioinspirados | Q-HORIZON | Q-STRUCTURES, Q-HPC | ORB-CSR, ORB-PMO |
+| 550–559 | Nanotecnología y Nanorobótica | Nanorobots, nanoassembly, nanostructures, nanoscale actuation | Q-HORIZON | Q-HPC, Q-STRUCTURES | ORB-PMO, ORB-LEG |
+| 560–569 | Sensores Avanzados Bio/Nano | Bio/nano sensors, structural health monitoring, smart sensing | Q-HORIZON | Q-DATAGOV, Q-HPC, Q-STRUCTURES | ORB-PMO, ORB-LEG |
+| 570–579 | Manufactura Aditiva para Materiales Avanzados | 3D printing, additive manufacturing, repair, qualification | Q-INDUSTRY | Q-STRUCTURES, Q-HPC | ORB-PMO, ORB-FIN |
+| 580–589 | Materiales y Procesos Cuánticos | Quantum materials, cryogenic materials, superconducting materials | Q-HORIZON | Q-STRUCTURES, Q-HPC, Q-GREENTECH | ORB-PMO, ORB-LEG |
+| 590–599 | Reciclaje y Sostenibilidad de Materiales | Circularity, recycling, DPP material traceability, eco-design | Q-STRUCTURES | Q-INDUSTRY, Q-DATAGOV | ORB-CSR, ORB-PMO |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `500–599` |
+| Sub-ranges | 10 |
+| Architecture code | `AMTA` |
+| Governance class | `baseline` |
+| Restricted band | No |
+| Primary Q-Divisions | Q-HORIZON, Q-INDUSTRY, Q-STRUCTURES |
+| Folder path | `Q+ATLANTIDE/500-599_AMTA/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
 
 ## Governance
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = AMTA`, `q_division_owner` and `orb_function_support`.
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = AMTA`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/500-599_AMTA/README.md
+++ b/Q+ATLANTIDE/500-599_AMTA/README.md
@@ -1,0 +1,16 @@
+# 500-599 AMTA — Advanced Material, Bio & Nanotechnology Architecture
+
+**Architecture Code:** AMTA
+**Master Range:** `500-599`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** Standard
+
+## Purpose
+
+Advanced materials, bio and nanotechnology architecture band covering composites, metamaterials, bio-derived materials, nanotechnology, recycling and circularity (LUTNDR-aligned), and material lifecycle traceability via Digital Product Passport (DPP).
+
+## Governance
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = AMTA`, `q_division_owner` and `orb_function_support`.
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.

--- a/Q+ATLANTIDE/600-699_OGATA/README.md
+++ b/Q+ATLANTIDE/600-699_OGATA/README.md
@@ -1,16 +1,101 @@
-# 600-699 OGATA — On-Ground Automation Technology Architecture
+---
+document_id: QATL-ATLAS1000-OGATA-README
+title: "600–699 OGATA — On-Ground Automation Technology Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: OGATA
+architecture_name: "On-Ground Automation Technology Architecture"
+master_range: "600–699"
+subrange_count: 10
+governance_class: baseline
+primary_q_divisions: [Q-GROUND, Q-HORIZON, Q-HPC, Q-INDUSTRY]
+orb_function_support: [ORB-CSR, ORB-FIN, ORB-HR, ORB-LEG, ORB-MKTG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** OGATA
-**Master Range:** `600-699`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** Standard
+# 600–699 OGATA — On-Ground Automation Technology Architecture
 
-## Purpose
+## 1. Purpose
 
-On-ground automation technology architecture band covering industrial robotics (including 6/7-axis assembly and welding robots — UTCS `600-10-10`), Human-Robot Interaction (HRI), ground support equipment (GSE), automated logistics, and ground-segment automation.
+On-ground automation technology architecture band covering industrial & collaborative robotics, autonomous ground vehicles, smart infrastructure, Factory 4.0 & advanced manufacturing, automated logistics, precision agriculture, construction automation, indoor service robots, AI/quantum optimisation, and Human-Robot Interaction.
+
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
+
+## 2. Glossary of Terms & Acronyms
+
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| OGATA | On-Ground Automation Technology Architecture | Ground automation architecture band `600-699`. |
+| AGV | Automated Guided Vehicle | Path-following autonomous transport unit. |
+| AMR | Autonomous Mobile Robot | Free-navigating autonomous transport unit. |
+| FAL | Final Assembly Line | Manufacturing assembly stage. |
+| HRI | Human-Robot Interaction | Ground automation and collaborative robotics. |
+| MES | Manufacturing Execution System | Factory production management software. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
+
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
+
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 600–609 | Robótica Industrial y Colaborativa | Robots industriales, cobots, automation cells, safety | Q-INDUSTRY | Q-HPC, Q-GROUND | ORB-PMO, ORB-FIN |
+| 610–619 | Vehículos Autónomos Terrestres | AGV, AMR, autonomous towing, yard automation | Q-GROUND | Q-HPC, Q-INDUSTRY, Q-DATAGOV | ORB-PMO, ORB-FIN |
+| 620–629 | Infraestructura Inteligente | Smart infrastructure, connected facilities, sensorized ground systems | Q-GROUND | Q-DATAGOV, Q-INDUSTRY | ORB-FIN, ORB-PMO |
+| 630–639 | Fábricas 4.0 y Manufactura Avanzada | Digital manufacturing, FAL automation, MES, robotics | Q-INDUSTRY | Q-DATAGOV, Q-HPC | ORB-PMO, ORB-FIN |
+| 640–649 | Logística y Almacenamiento Automatizado | Warehousing, automated logistics, supply chain robotics | Q-INDUSTRY | Q-GROUND, Q-DATAGOV | ORB-FIN, ORB-PMO |
+| 650–659 | Agricultura de Precisión | Agro-automation, robotics, monitoring, autonomous farming systems | Q-HORIZON | Q-HPC, Q-GROUND | ORB-CSR, ORB-MKTG |
+| 660–669 | Construcción y Demolición Automatizada | Construction robotics, demolition automation, autonomous site operations | Q-GROUND | Q-INDUSTRY, Q-HPC | ORB-PMO, ORB-LEG |
+| 670–679 | Servicios Autónomos en Entornos Cerrados | Indoor robotics, maintenance support, facility service robots | Q-GROUND | Q-HPC, Q-DATAGOV | ORB-PMO, ORB-HR |
+| 680–689 | Optimización con IA y Cuántica | Scheduling, routing, quantum optimization, logistics intelligence | Q-HPC | Q-DATAGOV, Q-INDUSTRY | ORB-PMO, ORB-FIN |
+| 690–699 | Interacción Humano-Robot y Seguridad | HRI, safety cases, human factors, collaborative procedures | Q-INDUSTRY | Q-HPC, Q-GROUND | ORB-HR, ORB-LEG |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `600–699` |
+| Sub-ranges | 10 |
+| Architecture code | `OGATA` |
+| Governance class | `baseline` |
+| Restricted band | No |
+| Primary Q-Divisions | Q-GROUND, Q-HORIZON, Q-HPC, Q-INDUSTRY |
+| Folder path | `Q+ATLANTIDE/600-699_OGATA/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
 
 ## Governance
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = OGATA`, `q_division_owner` and `orb_function_support`.
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = OGATA`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/600-699_OGATA/README.md
+++ b/Q+ATLANTIDE/600-699_OGATA/README.md
@@ -1,0 +1,16 @@
+# 600-699 OGATA — On-Ground Automation Technology Architecture
+
+**Architecture Code:** OGATA
+**Master Range:** `600-699`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** Standard
+
+## Purpose
+
+On-ground automation technology architecture band covering industrial robotics (including 6/7-axis assembly and welding robots — UTCS `600-10-10`), Human-Robot Interaction (HRI), ground support equipment (GSE), automated logistics, and ground-segment automation.
+
+## Governance
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = OGATA`, `q_division_owner` and `orb_function_support`.
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.

--- a/Q+ATLANTIDE/700-799_ACV/README.md
+++ b/Q+ATLANTIDE/700-799_ACV/README.md
@@ -1,16 +1,101 @@
-# 700-799 ACV — Aerial City Viability
+---
+document_id: QATL-ATLAS1000-ACV-README
+title: "700–799 ACV — Aerial City Viability / UAM Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: ACV
+architecture_name: "Aerial City Viability / UAM Architecture"
+master_range: "700–799"
+subrange_count: 10
+governance_class: baseline
+primary_q_divisions: [Q-AIR, Q-DATAGOV, Q-GREENTECH, Q-GROUND, Q-HORIZON, Q-HPC]
+orb_function_support: [ORB-CSR, ORB-FIN, ORB-LEG, ORB-MKTG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** ACV
-**Master Range:** `700-799`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** Standard
+# 700–799 ACV — Aerial City Viability / UAM Architecture
 
-## Purpose
+## 1. Purpose
 
-Aerial city viability architecture band covering Urban Air Mobility (UAM), uncrewed/urban traffic management (UTM), vertiports and aerial-city infrastructure, electric VTOL platforms, and the operational ecosystem enabling aerial mobility within urban environments.
+Aerial city viability architecture band covering UAM vehicles, vertiport infrastructure, urban traffic management (UTM), noise & acoustics, environmental sustainability, certification & legal frameworks, urban interface & social acceptance, operational safety & resilience, quantum traffic optimisation, and UAM business models.
+
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
+
+## 2. Glossary of Terms & Acronyms
+
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| ACV | Aerial City Viability | UAM and aerial-city architecture band `700-799`. |
+| eVTOL | Electric Vertical Take-Off and Landing | Battery-electric VTOL aircraft platform. |
+| ESG | Environmental, Social and Governance | Sustainability reporting framework. |
+| UAM | Urban Air Mobility | Urban aerial mobility ecosystem. |
+| UTM | Uncrewed / Urban Traffic Management | Traffic-management domain for UAM / uncrewed operations. |
+| UX | User Experience | Human-centred interaction design. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
+
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
+
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 700–709 | Vehículos de Movilidad Aérea Urbana | eVTOL, UAM vehicles, urban air platforms | Q-AIR | Q-GREENTECH, Q-STRUCTURES, Q-HPC | ORB-MKTG, ORB-PMO |
+| 710–719 | Vertipuertos y Heliplataformas | Vertiports, charging/refuelling, passenger infrastructure | Q-GROUND | Q-GREENTECH, Q-INDUSTRY | ORB-FIN, ORB-PMO |
+| 720–729 | Gestión del Tráfico Aéreo Urbano | UTM, airspace integration, traffic management, autonomy | Q-AIR | Q-DATAGOV, Q-SPACE, Q-HPC | ORB-PMO, ORB-LEG |
+| 730–739 | Ruido y Acústica Urbana | Noise modelling, acoustic footprint, urban impact | Q-AIR | Q-HPC, Q-GREENTECH | ORB-CSR, ORB-MKTG |
+| 740–749 | Sostenibilidad Ambiental en UAM | Emissions, lifecycle impact, ESG, urban sustainability | Q-GREENTECH | Q-DATAGOV, Q-HPC | ORB-CSR, ORB-PMO |
+| 750–759 | Legal, Regulación y Certificación UAM | Certification, airworthiness, operating rules, liability | Q-DATAGOV | Q-AIR, Q-GROUND | ORB-LEG, ORB-PMO |
+| 760–769 | Interfaz Urbana y Aceptación Social | Human factors, accessibility, social acceptance, UX | Q-GROUND | Q-AIR, Q-DATAGOV | ORB-MKTG, ORB-CSR |
+| 770–779 | Seguridad y Resiliencia Operacional | Safety, emergency response, operational resilience | Q-AIR | Q-GROUND, Q-DATAGOV, Q-HPC | ORB-PMO, ORB-LEG |
+| 780–789 | Optimización Cuántica de Tráfico y Logística UAM | Quantum traffic optimization, urban logistics, routing | Q-HPC | Q-AIR, Q-DATAGOV, Q-HORIZON | ORB-PMO, ORB-FIN |
+| 790–799 | Modelos de Negocio y Ecosistemas UAM | Operators, business models, infrastructure partnerships | Q-HORIZON | Q-AIR, Q-GROUND | ORB-MKTG, ORB-FIN |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `700–799` |
+| Sub-ranges | 10 |
+| Architecture code | `ACV` |
+| Governance class | `baseline` |
+| Restricted band | No |
+| Primary Q-Divisions | Q-AIR, Q-DATAGOV, Q-GREENTECH, Q-GROUND, Q-HORIZON, Q-HPC |
+| Folder path | `Q+ATLANTIDE/700-799_ACV/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
 
 ## Governance
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = ACV`, `q_division_owner` and `orb_function_support`.
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = ACV`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/700-799_ACV/README.md
+++ b/Q+ATLANTIDE/700-799_ACV/README.md
@@ -1,0 +1,16 @@
+# 700-799 ACV — Aerial City Viability
+
+**Architecture Code:** ACV
+**Master Range:** `700-799`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** Standard
+
+## Purpose
+
+Aerial city viability architecture band covering Urban Air Mobility (UAM), uncrewed/urban traffic management (UTM), vertiports and aerial-city infrastructure, electric VTOL platforms, and the operational ecosystem enabling aerial mobility within urban environments.
+
+## Governance
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Templates in this band must declare `architecture_band`, `architecture_code = ACV`, `q_division_owner` and `orb_function_support`.
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.

--- a/Q+ATLANTIDE/800-899_CYB/README.md
+++ b/Q+ATLANTIDE/800-899_CYB/README.md
@@ -1,21 +1,109 @@
-# 800-899 CYB — Cybersecurity Architecture
+---
+document_id: QATL-ATLAS1000-CYB-README
+title: "800–899 CYB — Cybersecurity Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: CYB
+architecture_name: "Cybersecurity Architecture"
+master_range: "800–899"
+subrange_count: 10
+governance_class: restricted
+restricted_rule: N-006
+primary_q_divisions: [Q-DATAGOV, Q-HORIZON]
+orb_function_support: [ORB-HR, ORB-LEG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** CYB
-**Master Range:** `800-899`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** **Restricted** (per N-006)
+# 800–899 CYB — Cybersecurity Architecture
 
-## Purpose
+## 1. Purpose
 
-Cybersecurity architecture band covering Identity and Access Management (IAM), Post-Quantum Cryptography (PQC), Quantum Key Distribution (QKD), secure communications, supply-chain security, and resilience across all ATLAS-1000 architectures.
+Cybersecurity architecture band covering cyber governance & risk, network & communications security, data & storage protection, identity & access management, application & software security, security operations, cloud & edge security, ICS/OT security, post-quantum cryptography, and threat intelligence & cyber-resilience.
 
-## Governance & Restrictions
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Per **N-006**, templates with `architecture_band` in `800-899` are **restricted** and must additionally declare:
+## 2. Glossary of Terms & Acronyms
 
-- `evidence_package_id`
-- `access_control_profile`
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| CYB | Cybersecurity Architecture | Cybersecurity architecture band `800-899` (restricted). |
+| DLP | Data Loss Prevention | Class of controls preventing data exfiltration. |
+| IAM | Identity and Access Management | Cybersecurity access-control domain. |
+| ICS/OT | Industrial Control Systems / Operational Technology | Industrial automation security domain. |
+| PKI | Public Key Infrastructure | Asymmetric-key trust infrastructure. |
+| PQC | Post-Quantum Cryptography | Quantum-resistant cybersecurity family. |
+| QKD | Quantum Key Distribution | Quantum communications security method. |
+| SDLC | Software Development Life Cycle | End-to-end software engineering process. |
+| SOC | Security Operations Centre | Continuous detection and response function. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
 
-Templates must also declare `architecture_code = CYB`, `q_division_owner` (technical authority) and `orb_function_support` (enterprise support).
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 800–809 | Gobernanza y Gestión de Riesgos de Ciberseguridad | Cyber governance, risk management, compliance, policy | Q-DATAGOV | Q-HPC, Q-SPACE | ORB-LEG, ORB-PMO |
+| 810–819 | Seguridad de Redes y Comunicaciones | Network security, secure comms, zero trust, segmentation | Q-DATAGOV | Q-SPACE, Q-HPC | ORB-LEG, ORB-PMO |
+| 820–829 | Seguridad de Datos y Almacenamiento | Encryption, data integrity, secure storage, DLP | Q-DATAGOV | Q-HPC | ORB-LEG, ORB-PMO |
+| 830–839 | Gestión de Identidades y Acceso | IAM, PKI, access control, privileged access | Q-DATAGOV | Q-HPC | ORB-LEG, ORB-HR |
+| 840–849 | Seguridad de Aplicaciones y Software | Secure SDLC, code security, software assurance | Q-DATAGOV | Q-HPC | ORB-LEG, ORB-PMO |
+| 850–859 | Ciberseguridad Operacional | SecOps, SOC, detection, response, monitoring | Q-DATAGOV | Q-HPC, Q-GROUND | ORB-PMO, ORB-LEG |
+| 860–869 | Seguridad Cloud y Edge | Cloud security, edge security, distributed systems hardening | Q-DATAGOV | Q-HPC, Q-INDUSTRY | ORB-LEG, ORB-PMO |
+| 870–879 | Ciberseguridad ICS/OT | OT security, industrial control systems, FAL protection | Q-DATAGOV | Q-INDUSTRY, Q-GROUND | ORB-LEG, ORB-PMO |
+| 880–889 | Criptografía Post-Cuántica y Seguridad Cuántica | PQC, QKD, crypto-agility, quantum-safe transition | Q-HORIZON | Q-DATAGOV, Q-HPC, Q-SPACE | ORB-LEG, ORB-PMO |
+| 890–899 | Inteligencia de Amenazas y Ciber-resiliencia | Threat intelligence, resilience engineering, cyber recovery | Q-DATAGOV | Q-HPC, Q-HORIZON | ORB-LEG, ORB-PMO |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `800–899` |
+| Sub-ranges | 10 |
+| Architecture code | `CYB` |
+| Governance class | `restricted` |
+| Restricted band | Yes (rule N-006[^n006]) |
+| Primary Q-Divisions | Q-DATAGOV, Q-HORIZON |
+| Folder path | `Q+ATLANTIDE/800-899_CYB/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
+
+## Governance
+
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = CYB`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
+
+**Restricted band (N-006[^n006]).** Templates inside this band must additionally declare `governance_class: restricted`, `evidence_package_id` and `access_control_profile`.
+
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n006]: **Note N-006 (Restricted bands)** — Defence-related (`200-299` DTTA), cybersecurity-related (`800-899` CYB) and quantum-related (`900-999` QCSAA) bands require additional governance, evidence packages and access controls beyond the baseline trace record. Templates must additionally declare `governance_class: restricted`, `evidence_package_id` and `access_control_profile`. See [`organization/Q+ATLANTIDE.md` §5.3](../../organization/Q+ATLANTIDE.md#53-restricted-band-templates-n-006).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/800-899_CYB/README.md
+++ b/Q+ATLANTIDE/800-899_CYB/README.md
@@ -1,0 +1,21 @@
+# 800-899 CYB — Cybersecurity Architecture
+
+**Architecture Code:** CYB
+**Master Range:** `800-899`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** **Restricted** (per N-006)
+
+## Purpose
+
+Cybersecurity architecture band covering Identity and Access Management (IAM), Post-Quantum Cryptography (PQC), Quantum Key Distribution (QKD), secure communications, supply-chain security, and resilience across all ATLAS-1000 architectures.
+
+## Governance & Restrictions
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Per **N-006**, templates with `architecture_band` in `800-899` are **restricted** and must additionally declare:
+
+- `evidence_package_id`
+- `access_control_profile`
+
+Templates must also declare `architecture_code = CYB`, `q_division_owner` (technical authority) and `orb_function_support` (enterprise support).
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.

--- a/Q+ATLANTIDE/900-999_QCSAA/README.md
+++ b/Q+ATLANTIDE/900-999_QCSAA/README.md
@@ -1,21 +1,106 @@
-# 900-999 QCSAA — Quantum Computing & Sentient Agency Architecture
+---
+document_id: QATL-ATLAS1000-QCSAA-README
+title: "900–999 QCSAA — Quantum Computing & Sentient Agency Architecture"
+register: ATLAS-1000
+parent_baseline: Q+ATLANTIDE
+parent_baseline_doc: ../../organization/Q+ATLANTIDE.md
+architecture_code: QCSAA
+architecture_name: "Quantum Computing & Sentient Agency Architecture"
+master_range: "900–999"
+subrange_count: 10
+governance_class: restricted
+restricted_rule: N-006
+primary_q_divisions: [Q-DATAGOV, Q-HORIZON, Q-HPC, Q-SPACE]
+orb_function_support: [ORB-CSR, ORB-FIN, ORB-LEG, ORB-MKTG, ORB-PMO]
+version: 1.0.0
+status: active
+language: en
+---
 
-**Architecture Code:** QCSAA
-**Master Range:** `900-999`
-**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
-**Classification:** **Restricted** (per N-006)
+# 900–999 QCSAA — Quantum Computing & Sentient Agency Architecture
 
-## Purpose
+## 1. Purpose
 
-Quantum computing and sentient agency architecture band covering quantum computing platforms, Quantum Machine Learning (QML), quantum sensing, sentient-agency frameworks (including SENTIENTIT_zGen / regent-ZetaGentz governance), and the G10.975 containment grammar.
+Quantum computing and sentient agency architecture band covering quantum computing foundations, QML & quantum AI, quantum networks & communications, quantum cybersecurity, quantum sensing & metrology, quantum simulation, quantum-enhanced robotics, quantum sentient agency, AI/quantum ethics & governance, and cross-band future applications.
 
-## Governance & Restrictions
+This folder is part of the **ATLAS-1000** register, a subpart of the controlled **Q+ATLANTIDE** baseline[^baseline][^n001]. Bands classify technologies, Q-Divisions provide technical authority, and ORB-Functions provide enterprise support[^n002].
 
-Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Per **N-006**, templates with `architecture_band` in `900-999` are **restricted** and must additionally declare:
+## 2. Glossary of Terms & Acronyms
 
-- `evidence_package_id`
-- `access_control_profile`
+| Term / Acronym | Expansion | Meaning in this band |
+|---|---|---|
+| QCSAA | Quantum Computing & Sentient Agency Architecture | Quantum and sentient-agency architecture band `900-999` (restricted). |
+| QML | Quantum Machine Learning | Quantum / hybrid machine-learning methods. |
+| QKD | Quantum Key Distribution | Quantum communications security method. |
+| PQC | Post-Quantum Cryptography | Quantum-resistant cybersecurity family. |
+| Qubit | Quantum Bit | Fundamental unit of quantum information. |
+| G10.975 | Containment Grammar | Governance grammar for SENTIENTIT_zGen / regent-ZetaGentz; cross-referenced for `970-989`. |
+| Q+ATLANTIDE | Controlled baseline for the `000-999` architecture-band taxonomy. | Parent baseline of this register. |
+| ATLAS-1000 | Umbrella register of the 10 architectures inside Q+ATLANTIDE. | Subpart of Q+ATLANTIDE; not a numeric band. |
+| Q-Division | Technical authority unit (e.g. Q-AIR, Q-DATAGOV, Q-HPC). | Owns architecture decisions inside a band (rule N-002). |
+| ORB | Organizational Resource Backbone — enterprise support functions. | Provides enterprise-side support to bands (rule N-002). |
+| CSDB | Common Source DataBase | S1000D technical-publication data environment. |
+| LC | Lifecycle phase / acceptance gate | Used across SSOT/LC01–LC14. |
 
-Templates must also declare `architecture_code = QCSAA`, `q_division_owner` (technical authority) and `orb_function_support` (enterprise support).
+Cross-reference the full Q+ATLANTIDE acronym set at [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms)[^glossary].
 
-Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.
+## 3. Architecture Table
+
+Sub-ranges within this band, sourced from the Q+ATLANTIDE controlled baseline[^baseline] §3 *Consolidated Architecture Table*[^table].
+
+| Sub-range | Block | Primary focus | Primary Q-Division | Support Q-Divisions | ORB support |
+|---:|---|---|---|---|---|
+| 900–909 | Fundamentos de Computación Cuántica | Qubits, gates, circuits, quantum algorithms, foundations | Q-HORIZON | Q-HPC, Q-DATAGOV | ORB-PMO, ORB-LEG |
+| 910–919 | Quantum Machine Learning e IA Cuántica | QML, hybrid quantum-classical AI, optimization learning | Q-HPC | Q-HORIZON, Q-DATAGOV | ORB-PMO, ORB-LEG |
+| 920–929 | Redes y Comunicaciones Cuánticas | Quantum networks, QKD, entanglement distribution | Q-SPACE | Q-HORIZON, Q-DATAGOV | ORB-PMO, ORB-LEG |
+| 930–939 | Ciberseguridad Cuántica | Quantum-safe security, quantum cyber, crypto transition | Q-DATAGOV | Q-HORIZON, Q-HPC | ORB-LEG, ORB-PMO |
+| 940–949 | Sensores y Metrología Cuántica | Quantum sensing, gravimetry, timing, navigation, metrology | Q-HORIZON | Q-SPACE, Q-AIR, Q-HPC | ORB-PMO, ORB-LEG |
+| 950–959 | Simulación Cuántica | Quantum simulation, materials simulation, physics modelling | Q-HPC | Q-HORIZON, Q-STRUCTURES, Q-GREENTECH | ORB-PMO, ORB-FIN |
+| 960–969 | Robótica Cuántica y Manipulación de Materia | Quantum-enhanced robotics, precision manipulation, matter control | Q-HORIZON | Q-HPC, Q-INDUSTRY | ORB-PMO, ORB-LEG |
+| 970–979 | Agencia Sentiente Cuántica | Sentient agency models, quantum-classical agency, autonomy governance | Q-HORIZON | Q-HPC, Q-DATAGOV | ORB-LEG, ORB-PMO |
+| 980–989 | Gobernanza y Ética de IA y Cuántica Sentiente | AI ethics, quantum governance, agency constraints, auditability | Q-DATAGOV | Q-HORIZON, Q-HPC | ORB-LEG, ORB-CSR |
+| 990–999 | Futuro QCSAA y Aplicaciones Inter-Arquitectura | Cross-band applications, future architectures, post-2040 systems | Q-HORIZON | Q-HPC, Q-SPACE, Q-DATAGOV | ORB-PMO, ORB-MKTG |
+
+## 4. Footprint
+
+| Metric | Value |
+|---|---|
+| Master range | `900–999` |
+| Sub-ranges | 10 |
+| Architecture code | `QCSAA` |
+| Governance class | `restricted` |
+| Restricted band | Yes (rule N-006[^n006]) |
+| Primary Q-Divisions | Q-DATAGOV, Q-HORIZON, Q-HPC, Q-SPACE |
+| Folder path | `Q+ATLANTIDE/900-999_QCSAA/` |
+| Documents | `README.md` (this file) |
+| Parent baseline | [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md) |
+| Register subpart | ATLAS-1000 |
+
+## Governance
+
+Governed by [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md)[^baseline]. Templates declared in this band must populate `architecture_band`, `architecture_code = QCSAA`, `q_division_owner` and `orb_function_support` per the Templates System[^templates]. The No-AAA Rule[^n004] applies.
+
+**Restricted band (N-006[^n006]).** Templates inside this band must additionally declare `governance_class: restricted`, `evidence_package_id` and `access_control_profile`.
+
+## 5. References & Citations
+
+
+[^baseline]: **Q+ATLANTIDE controlled baseline (v1.0.0)** — [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Defines the controlled `000-999` architecture-band taxonomy and the ATLAS-1000 register subpart.
+
+[^table]: **§3 — Consolidated Architecture Table** — [`organization/Q+ATLANTIDE.md` §3](../../organization/Q+ATLANTIDE.md#3-consolidated-architecture-table).
+
+[^glossary]: **§2 — Acronyms** — [`organization/Q+ATLANTIDE.md` §2](../../organization/Q+ATLANTIDE.md#2-acronyms).
+
+[^templates]: **§5 — Templates System** — [`organization/Q+ATLANTIDE.md` §5](../../organization/Q+ATLANTIDE.md#5-templates-system). Mandatory template header fields, naming rules and lifecycle integration.
+
+[^n001]: **Note N-001** — Q+ATLANTIDE (with its ATLAS-1000 register subpart) is a taxonomy and traceability ecosystem, not an organization chart. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n002]: **Note N-002** — Architecture bands classify technologies; Q-Divisions provide technical authority; ORB-Functions provide enterprise support. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n003]: **Note N-003** — The `000-999` range is controlled; `ATLAS-1000` is the umbrella name, not an additional numeric band. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n004]: **Note N-004 (No-AAA Rule)** — "AAA" is not a valid domain, division, architecture, interface or function in this baseline. See [`organization/Q+ATLANTIDE.md` §4](../../organization/Q+ATLANTIDE.md#4-notes).
+
+[^n006]: **Note N-006 (Restricted bands)** — Defence-related (`200-299` DTTA), cybersecurity-related (`800-899` CYB) and quantum-related (`900-999` QCSAA) bands require additional governance, evidence packages and access controls beyond the baseline trace record. Templates must additionally declare `governance_class: restricted`, `evidence_package_id` and `access_control_profile`. See [`organization/Q+ATLANTIDE.md` §5.3](../../organization/Q+ATLANTIDE.md#53-restricted-band-templates-n-006).
+
+[^repo]: **Repository root README** — [`README.md`](../../README.md). Top-level entry point referencing the Q+ATLANTIDE baseline and the ATLAS-1000 register subpart.

--- a/Q+ATLANTIDE/900-999_QCSAA/README.md
+++ b/Q+ATLANTIDE/900-999_QCSAA/README.md
@@ -1,0 +1,21 @@
+# 900-999 QCSAA — Quantum Computing & Sentient Agency Architecture
+
+**Architecture Code:** QCSAA
+**Master Range:** `900-999`
+**Register:** ATLAS-1000 (subpart of Q+ATLANTIDE)
+**Classification:** **Restricted** (per N-006)
+
+## Purpose
+
+Quantum computing and sentient agency architecture band covering quantum computing platforms, Quantum Machine Learning (QML), quantum sensing, sentient-agency frameworks (including SENTIENTIT_zGen / regent-ZetaGentz governance), and the G10.975 containment grammar.
+
+## Governance & Restrictions
+
+Governed by the controlled baseline [`organization/Q+ATLANTIDE.md`](../../organization/Q+ATLANTIDE.md). Per **N-006**, templates with `architecture_band` in `900-999` are **restricted** and must additionally declare:
+
+- `evidence_package_id`
+- `access_control_profile`
+
+Templates must also declare `architecture_code = QCSAA`, `q_division_owner` (technical authority) and `orb_function_support` (enterprise support).
+
+Refer to `organization/Q+ATLANTIDE.md` §3 for subrange definitions and Q-Division mapping.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Introduce README documentation for each ATLAS-1000 architecture band (ATLAS, STA, DTTA, DTCEC, EPTA, AMTA, OGATA, ACV, CYB, QCSAA), detailing purpose, sub-range taxonomy, governance model, and references to the Q+ATLANTIDE baseline.